### PR TITLE
POST to Sendgrid instead of GET

### DIFF
--- a/src/greplin/tornado/sendgrid.py
+++ b/src/greplin/tornado/sendgrid.py
@@ -48,9 +48,8 @@ class Sendgrid(object):
         logging.error("Message not sent. Missing required argument %s", required)
         callback(None)
         return
-    credentials = {'api_user':self._user, 'api_key':self._secret}
-    api_url = "%s.%s?%s" % (self._BASE_URL, self._FORMAT,
-                        urllib.urlencode(credentials))
+    kwargs.update({'api_user':self._user, 'api_key':self._secret})
+    api_url = "%s.%s" % (self._BASE_URL, self._FORMAT)
     post_body = urllib.urlencode(kwargs)
     http = httpclient.AsyncHTTPClient()
     request = httpclient.HTTPRequest(api_url, method='POST', body=post_body)

--- a/src/greplin/tornado/sendgrid.py
+++ b/src/greplin/tornado/sendgrid.py
@@ -48,10 +48,13 @@ class Sendgrid(object):
         logging.error("Message not sent. Missing required argument %s", required)
         callback(None)
         return
-    kwargs.update({'api_user':self._user, 'api_key':self._secret})
-    url = "%s.%s?%s" % (self._BASE_URL, self._FORMAT, urllib.urlencode(kwargs))
+    credentials = {'api_user':self._user, 'api_key':self._secret}
+    api_url = "%s.%s?%s" % (self._BASE_URL, self._FORMAT,
+                        urllib.urlencode(credentials))
+    post_body = urllib.urlencode(kwargs)
     http = httpclient.AsyncHTTPClient()
-    http.fetch(url, functools.partial(self._on_sendgrid_result, callback))
+    request = httpclient.HTTPRequest(api_url, method='POST', body=post_body)
+    http.fetch(request, functools.partial(self._on_sendgrid_result, callback))
 
 
   def _on_sendgrid_result(self, callback, result):


### PR DESCRIPTION
When sending HTML emails of a nontrivial size, Sendgrid panicked due to the URL length when using GET params.
